### PR TITLE
Fix outdated personal website link

### DIFF
--- a/Tech/04~Middleware/DistributedSystem/01~DistributedSystem/Consensus/Consensus-List.md
+++ b/Tech/04~Middleware/DistributedSystem/01~DistributedSystem/Consensus/Consensus-List.md
@@ -30,7 +30,7 @@
 
 # Consensus Algorithms
 
-- [In search of a simple consensus algorithm](http://rystsov.info/2017/02/15/simple-consensus.html)
+- [In search of a simple consensus algorithm](http://rystsov.com/2017/02/15/simple-consensus.html)
 
 # OpenSource
 


### PR DESCRIPTION
Replaces outdated link `rystsov.info` with the current official site:

https://rystsov.com

The previous domain is no longer maintained.